### PR TITLE
Implement UI functions and export entry points

### DIFF
--- a/app/rust/include/rslib.h
+++ b/app/rust/include/rslib.h
@@ -4,8 +4,12 @@
 #include "parser_common.h"
 #include "parser_txdef.h"
 
-// Signature must be 48 bytes and key 96 bytes
-// Returns 1 if signature is valid, 0 otherwise
-uint8_t verify_bls_sign(const uint8_t *msg, uint16_t msg_len, const uint8_t *sk, uint8_t *sig);
+parser_error_t rs_getNumItems(const parser_context_t *ctx, uint8_t *num_items);
+
+parser_error_t rs_getItem(const parser_context_t *ctx,
+                              int8_t displayIdx,
+                              char *outKey, uint16_t outKeyLen,
+                              char *outValue, uint16_t outValueLen,
+                              uint8_t pageIdx, uint8_t *pageCount);
 
 

--- a/app/rust/src/constants.rs
+++ b/app/rust/src/constants.rs
@@ -18,6 +18,7 @@ pub const BLS_SIGNATURE_SIZE: usize = 48;
 pub const MAX_LINES: usize = 2;
 pub const MAX_PAGES: usize = 20;
 pub const MAX_CHARS_PER_LINE: usize = 32;
+pub const REPLY_PATH: &str = "reply";
 
 pub const CBOR_TAG: u64 = 55799;
 pub const CBOR_CERTIFICATE_TAG: u64 = CBOR_TAG;

--- a/app/rust/src/error.rs
+++ b/app/rust/src/error.rs
@@ -17,7 +17,7 @@ use minicbor::decode::Error;
 use nom::error::ErrorKind;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-debug", derive(Debug))]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub enum ViewError {
     Unknown,
     NoData,
@@ -25,7 +25,7 @@ pub enum ViewError {
 }
 
 #[repr(u32)]
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum ParserError {
     // Generic errors
     Ok = 0,
@@ -75,6 +75,7 @@ pub enum ParserError {
     InvalidCallRequest,
     InvalidConsentMsgRequest,
     InvalidCanisterId,
+    InvalidLanguage,
 }
 
 // minicibor error provides a reach

--- a/app/rust/src/ffi.rs
+++ b/app/rust/src/ffi.rs
@@ -1,26 +1,17 @@
-use crate::constants::{BLS_PUBLIC_KEY_SIZE, BLS_SIGNATURE_SIZE};
-use bls_signature::verify_bls_signature;
-
-/// The signature must be exactly 48 bytes (compressed G1 element)
-/// The key must be exactly 96 bytes (compressed G2 element)
-/// # Safety
-/// This function is unsafe because it dereferences raw pointers.
-/// but should be safe as long as input data meets the size requirements.
-#[no_mangle]
-pub unsafe extern "C" fn verify_bls_sign(
-    msg: *const u8,
-    msg_len: u16,
-    key: *const u8,
-    sig: *const u8,
-) -> u8 {
-    // Check for null pointers before converting to slices
-    if msg.is_null() || key.is_null() || sig.is_null() {
-        return false as u8;
-    }
-
-    let msg = std::slice::from_raw_parts(msg, msg_len as usize);
-    let key = std::slice::from_raw_parts(key, BLS_PUBLIC_KEY_SIZE);
-    let sig = std::slice::from_raw_parts(sig, BLS_SIGNATURE_SIZE);
-
-    verify_bls_signature(sig, msg, key).is_ok() as u8
-}
+/*******************************************************************************
+*   (c) 2024 Zondax AG
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+mod context;
+mod ui;

--- a/app/rust/src/ffi/context.rs
+++ b/app/rust/src/ffi/context.rs
@@ -1,0 +1,54 @@
+/*******************************************************************************
+*   (c) 2024 Zondax AG
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+// typedef struct {
+//     const uint8_t *buffer;
+//     uint16_t bufferLen;
+//     uint16_t offset;
+//     instruction_t ins;
+//     parser_tx_t tx_obj;
+// } parser_context_t;
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct parser_context_t {
+    pub buffer: *const u8,
+    pub buffer_len: u16,
+    pub offset: u16,
+    pub ins: u8,
+    pub tx_obj: parse_tx_t,
+}
+
+// typedef struct {
+//     uint8_t *state;
+//     uint32_t len;
+// } parser_tx_t;
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct parse_tx_t {
+    pub state: *mut u8,
+    pub len: u32,
+}
+
+/// Cast a *mut u8 to a *mut Transaction
+#[macro_export]
+macro_rules! certificate_from_state {
+    ($ptr:expr) => {
+        unsafe {
+            &mut (*core::ptr::addr_of_mut!((*$ptr).tx_obj.state)
+                .cast::<core::mem::MaybeUninit<$crate::Certificate>>())
+        }
+    };
+}

--- a/app/rust/src/ffi/ui.rs
+++ b/app/rust/src/ffi/ui.rs
@@ -1,0 +1,72 @@
+/*******************************************************************************
+*   (c) 2024 Zondax AG
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+use crate::{error::ParserError, DisplayableItem};
+
+use super::context::parser_context_t;
+use crate::certificate_from_state;
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_getNumItems(ctx: *const parser_context_t, num_items: *mut u8) -> u32 {
+    if num_items.is_null() || ctx.is_null() {
+        return ParserError::ContextMismatch as u32;
+    }
+
+    let tx = certificate_from_state!(ctx as *mut parser_context_t);
+    let obj = tx.assume_init_mut();
+
+    let Ok(num) = obj.num_items() else {
+        return ParserError::NoData as _;
+    };
+
+    *num_items = num;
+
+    ParserError::Ok as u32
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_getItem(
+    ctx: *const parser_context_t,
+    display_idx: u8,
+    out_key: *mut i8,
+    key_len: u16,
+    out_value: *mut i8,
+    out_len: u16,
+    page_idx: u8,
+    page_count: *mut u8,
+) -> u32 {
+    *page_count = 0u8;
+
+    let page_count = &mut *page_count;
+
+    let key = core::slice::from_raw_parts_mut(out_key as *mut u8, key_len as usize);
+    let value = core::slice::from_raw_parts_mut(out_value as *mut u8, out_len as usize);
+
+    if ctx.is_null() {
+        return ParserError::ContextMismatch as u32;
+    }
+
+    let tx = certificate_from_state!(ctx as *mut parser_context_t);
+    let obj = tx.assume_init_mut();
+
+    match obj.render_item(display_idx, key, value, page_idx) {
+        Ok(page) => {
+            *page_count = page;
+            ParserError::Ok as _
+        }
+        Err(_) => ParserError::NoData as _,
+    }
+}

--- a/app/rust/src/parser/certificate/canister_ranges.rs
+++ b/app/rust/src/parser/certificate/canister_ranges.rs
@@ -7,13 +7,15 @@ use crate::{constants::CANISTER_RANGES_TAG, error::ParserError, FromBytes};
 const CANISTER_RANGE_SIZE: usize = 2;
 const MAX_PRINCIPAL_SIZE: usize = 29;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct CanisterRanges<'a> {
     len: usize,
     data: &'a [u8],
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 struct CanisterRangeIterator<'a> {
     len: usize,
     current: usize,

--- a/app/rust/src/parser/certificate/delegation.rs
+++ b/app/rust/src/parser/certificate/delegation.rs
@@ -28,7 +28,8 @@ const DELEGATION_MAP_ENTRIES: u64 = 2;
 const SUBNET_ID: &str = "subnet_id";
 const CERTIFICATE: &str = "certificate";
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct Delegation<'a> {
     pub subnet_id: SubnetId<'a>,
     pub certificate: RawValue<'a>,
@@ -37,14 +38,22 @@ pub struct Delegation<'a> {
 impl<'a> Delegation<'a> {
     pub fn cert(&self) -> Certificate<'a> {
         // Safe to unwrap because certificate parsing what check before
-        Certificate::parse(self.certificate.bytes()).unwrap()
+        let Ok(cert) = Certificate::parse(self.certificate.bytes()) else {
+            unreachable!();
+        };
+
+        cert
     }
 
     pub fn tree(&self) -> HashTree<'a> {
         let cert = self.cert();
         // Safe to unwrap as this was checked
         // when Delegation was parsed
-        cert.tree().try_into().unwrap()
+        let Ok(tree) = cert.tree().try_into() else {
+            unreachable!();
+        };
+
+        tree
     }
 
     fn subnet(&self) -> &'a [u8] {

--- a/app/rust/src/parser/certificate/hash_tree.rs
+++ b/app/rust/src/parser/certificate/hash_tree.rs
@@ -20,7 +20,8 @@ use sha2::Digest;
 use super::{label::Label, raw_value::RawValue};
 const MAX_TREE_DEPTH: usize = 32;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub enum HashTree<'a> {
     Empty,
     Fork(RawValue<'a>, RawValue<'a>),
@@ -289,7 +290,7 @@ impl<'b, C> Decode<'b, C> for HashTree<'b> {
     }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub enum LookupResult<'a> {
     Found(RawValue<'a>),
     Absent,
@@ -378,7 +379,6 @@ mod hash_tree_tests {
 
         let found = HashTree::lookup_path(&path, cert.tree()).unwrap();
         assert!(found.value().is_some());
-        HashTree::parse_and_print_hash_tree(&cert.tree(), 0);
     }
 
     #[test]

--- a/app/rust/src/parser/certificate/label.rs
+++ b/app/rust/src/parser/certificate/label.rs
@@ -15,7 +15,8 @@
 ********************************************************************************/
 use minicbor::{decode::Error, Decode, Decoder};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub enum Label<'a> {
     Blob(&'a [u8]),
     String(&'a str),

--- a/app/rust/src/parser/certificate/pubkey.rs
+++ b/app/rust/src/parser/certificate/pubkey.rs
@@ -19,7 +19,8 @@ use crate::constants::BLS_PUBLIC_KEY_SIZE;
 
 use super::raw_value::RawValue;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct PublicKey<'a>(&'a [u8; BLS_PUBLIC_KEY_SIZE]);
 
 impl<'a> PublicKey<'a> {

--- a/app/rust/src/parser/certificate/raw_value.rs
+++ b/app/rust/src/parser/certificate/raw_value.rs
@@ -15,7 +15,8 @@
 ********************************************************************************/
 use minicbor::{decode::Error, Decode, Decoder};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct RawValue<'a>(&'a [u8]);
 
 impl<'a> RawValue<'a> {

--- a/app/rust/src/parser/certificate/signature.rs
+++ b/app/rust/src/parser/certificate/signature.rs
@@ -19,7 +19,8 @@ use crate::constants::BLS_SIGNATURE_SIZE;
 
 use super::raw_value::RawValue;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct Signature<'a>(&'a [u8; BLS_SIGNATURE_SIZE]);
 
 impl<'a> Signature<'a> {

--- a/app/rust/src/parser/certificate/subnet_id.rs
+++ b/app/rust/src/parser/certificate/subnet_id.rs
@@ -17,7 +17,8 @@ use minicbor::{data::Type, decode::Error, Decode, Decoder};
 
 use super::raw_value::RawValue;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct SubnetId<'a>(RawValue<'a>);
 
 impl<'a> SubnetId<'a> {

--- a/app/rust/src/parser/consent_message/msg.rs
+++ b/app/rust/src/parser/consent_message/msg.rs
@@ -62,7 +62,8 @@ impl<'a, const PAGES: usize, const LINES: usize> ConsentMessage<'a, PAGES, LINES
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct Page<'a, const L: usize> {
     lines: [&'a str; L],
     num_lines: usize,

--- a/app/rust/src/parser/consent_message/msg_info.rs
+++ b/app/rust/src/parser/consent_message/msg_info.rs
@@ -15,15 +15,15 @@
 ********************************************************************************/
 use crate::{
     constants::{MAX_LINES, MAX_PAGES},
-    error::ParserError,
-    FromBytes,
+    error::{ParserError, ViewError},
+    DisplayableItem, FromBytes,
 };
 use core::{mem::MaybeUninit, ptr::addr_of_mut};
 
 use super::{msg::ConsentMessage, msg_metadata::ConsentMessageMetadata};
 
-#[derive(Debug)]
 #[repr(C)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct ConsentInfo<'a> {
     pub message: ConsentMessage<'a, MAX_PAGES, MAX_LINES>,
     pub metadata: ConsentMessageMetadata<'a>,
@@ -45,5 +45,23 @@ impl<'a> FromBytes<'a> for ConsentInfo<'a> {
         let rem = ConsentMessage::from_bytes_into(rem, message)?;
 
         Ok(rem)
+    }
+}
+
+impl<'a> DisplayableItem for ConsentInfo<'a> {
+    #[inline(never)]
+    fn num_items(&self) -> Result<u8, ViewError> {
+        self.message.num_items()
+    }
+
+    #[inline(never)]
+    fn render_item(
+        &self,
+        item_n: u8,
+        title: &mut [u8],
+        message: &mut [u8],
+        page: u8,
+    ) -> Result<u8, ViewError> {
+        self.message.render_item(item_n, title, message, page)
     }
 }

--- a/app/rust/src/parser/consent_message/msg_metadata.rs
+++ b/app/rust/src/parser/consent_message/msg_metadata.rs
@@ -22,8 +22,8 @@ use crate::{
     FromBytes,
 };
 
-#[derive(Debug)]
 #[repr(C)]
+#[cfg_attr(any(feature = "derive-debug", test), derive(Debug))]
 pub struct ConsentMessageMetadata<'a> {
     pub language: &'a str,
     // offset in minutes
@@ -40,6 +40,10 @@ impl<'a> FromBytes<'a> for ConsentMessageMetadata<'a> {
         // read first the utc_offset, its hash is < than the language hash
         let (rem, utc_offset) = parse_opt_i16(rem)?;
         let (rem, language) = parse_text(rem)?;
+
+        if language.is_empty() || language != "en" {
+            return Err(ParserError::InvalidLanguage);
+        }
 
         let out = out.as_mut_ptr();
 

--- a/app/src/common/actions.h
+++ b/app/src/common/actions.h
@@ -22,8 +22,6 @@
 #include <os_io_seproxyhal.h>
 #include "coin.h"
 #include "zxerror.h"
-// TODO: remove later
-#include "rslib.h"
 
 extern uint16_t action_addrResponseLen;
 
@@ -58,23 +56,6 @@ __Z_INLINE void app_sign_combined() {
 }
 
 __Z_INLINE zxerr_t app_fill_address() {
-    // Definition of the private key array
-    uint8_t pvk[96] = {136, 241, 121, 119, 242, 65, 192, 110, 129, 119, 65, 77, 158, 13, 150, 144, 28, 235, 33, 208, 173, 221, 78, 19, 60, 123, 224, 65, 6, 100, 121, 203, 211, 101, 20, 169, 44, 125, 233, 145, 41, 91, 200, 233, 176, 158, 87, 101, 14, 124, 251, 239, 197, 63, 193, 29, 63, 169, 173, 27, 106, 244, 66, 35, 18, 131, 154, 12, 85, 56, 162, 240, 100, 125, 155, 115, 241, 135, 95, 223, 191, 44, 141, 140, 9, 202, 43, 152, 228, 117, 44, 46, 126, 194, 128, 157};
-    // Definition of the message array
-    uint8_t message[11] = {104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100};
-    // Definition of the signature array
-    uint8_t signature[48]= {139, 118, 54, 85, 203, 37, 178, 69, 140, 15, 123, 156, 250, 54, 205, 107, 22, 254, 170, 98, 234, 151, 252, 248, 245, 75, 211, 209, 237, 75, 135, 119, 53, 244, 174, 38, 241, 127, 34, 154, 2, 92, 174, 10, 73, 110, 128, 24};
-
-    zemu_log_stack("\n calling verify_bls_sign!!!***\n");
-    if (verify_bls_sign(message, 11, pvk, signature) == 1)
-    {
-        zemu_log_stack("\nverify_bls_sign_done!!!***\n");
-    }
-    else
-    {
-        zemu_log_stack("\nverify_bls_sign_failed!!!***\n");
-    }
-
     CHECK_APP_CANARY();
 
     // Put data directly in the apdu buffer


### PR DESCRIPTION
- remove testing code from actions.h
- implement DisplayableItem trait to certificate and inner message structures
- display ConsentMessage, this needs to be tested regarding inner message structure on a real device
- display error message description, although this could be simplified by showing only error variant description, because the received message desc could contain unsupported symbols, which need to be tested
- implement UI entry points
